### PR TITLE
增加 mapstruct 支援

### DIFF
--- a/src/main/resources/templates/project/build.gradle.mustache
+++ b/src/main/resources/templates/project/build.gradle.mustache
@@ -1,14 +1,4 @@
-plugins {
-  id 'org.springframework.boot' version '2.7.0'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'java'
-  id 'jacoco'
-}
-
-group = '{{groupId}}'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
-
+@@ -12,48 +12,54 @@ sourceCompatibility = '17'
 configurations {
   compileOnly {
     extendsFrom annotationProcessor
@@ -21,6 +11,8 @@ repositories {
 
 ext {
   set('springCloudVersion', "2021.0.3")
+  set('mapstructVersion', "1.5.3.Final") // https://search.maven.org/artifact/org.mapstruct/mapstruct
+  set('lombokMapstructBindingVersion', "0.2.0")
   set('testcontainersVersion', "1.17.3") // https://search.maven.org/artifact/org.testcontainers/testcontainers-bom
   set('springCloudGcpVersion', "3.3.0") // https://search.maven.org/artifact/com.google.cloud/spring-cloud-gcp-dependencies
   set('springdocVersion', "1.6.11") // https://search.maven.org/artifact/org.springdoc/springdoc-openapi-ui
@@ -45,6 +37,10 @@ dependencies {
   runtimeOnly 'org.postgresql:postgresql'
   compileOnly 'org.projectlombok:lombok'
   annotationProcessor 'org.projectlombok:lombok'
+  // mapstruct
+  implementation "org.mapstruct:mapstruct:${mapstructVersion}"
+  annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+  annotationProcessor "org.projectlombok:lombok-mapstruct-binding:${lombokMapstructBindingVersion}"
   //
   implementation "org.springdoc:springdoc-openapi-ui:${springdocVersion}"
   implementation "org.springdoc:springdoc-openapi-data-rest:${springdocVersion}"
@@ -57,11 +53,7 @@ dependencies {
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-metrics'
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging'
   // chaos-monkey
-	implementation "de.codecentric:chaos-monkey-spring-boot:${chaosMonkeyVersion}"
-  // for test
-  testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+@@ -65,24 +71,30 @@ dependencies {
   testImplementation 'org.testcontainers:junit-jupiter'
   testImplementation 'org.testcontainers:postgresql'
 }
@@ -72,6 +64,12 @@ dependencyManagement {
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:${springCloudGcpVersion}"
   }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs = [
+      '-Amapstruct.verbose=true'
+    ]
 }
 
 tasks.named('test') {
@@ -86,6 +84,3 @@ jacocoTestReport {
 		// sonar analysis equired
 		xml.required.set(true)
 		csv.required.set(true)
-		html.required.set(true)
-	}
-}

--- a/src/main/resources/templates/project/build.gradle.mustache
+++ b/src/main/resources/templates/project/build.gradle.mustache
@@ -68,7 +68,8 @@ dependencyManagement {
 
 tasks.withType(JavaCompile) {
     options.compilerArgs = [
-      '-Amapstruct.verbose=true'
+      '-Amapstruct.verbose=true',
+      '-Amapstruct.defaultComponentModel=spring'
     ]
 }
 


### PR DESCRIPTION

- 專案產生時預設提供 mapstruct 
- 產生出的程式碼，屬於 Component，亦可使用 **@Autowired** 方式使用
```shell
> Task :compileJava
Note: MapStruct: Using accessor naming strategy: org.mapstruct.ap.spi.DefaultAccessorNamingStrategy
Note: MapStruct: Using builder provider: org.mapstruct.ap.spi.DefaultBuilderProvider
Note: MapStruct: Using enum naming strategy: org.mapstruct.ap.spi.DefaultEnumMappingStrategy
Note:  MapStruct: processing: com.example.demo.interfaces.rest.assembler.MapStructAssembler.
Note: - MapStruct: creating bean mapping method implementation for com.example.demo.infrastructure.repositories.tables.pojos.Goods toGoods(java.lang.String id).
Note: -- MapStruct: mapping property: id to: setId(java.lang.String).
Note: -- MapStruct: selecting property mapping: id.
/Users/ethan/Desktop/demo/src/main/java/com/example/demo/interfaces/rest/assembler/MapStructAssembler.java:8: warning: Unmapped target properties: "goodsName, unitPrice, inventory, currentVersions, createdBy, createdDate, lastModifiedBy, lastModifiedDate".
    Goods toGoods(String id);
          ^
Note: /Users/ethan/Desktop/demo/src/main/java/com/example/demo/infrastructure/repositories/GoodsRepository.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
```